### PR TITLE
Bora's attempt at addressing the frontend-challenge

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/node": "^12.0.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
+    "lodash": "^4.17.21",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",
@@ -44,10 +45,11 @@
     ]
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.179",
     "eslint-config-prettier": "^8.1.0",
-    "prettier": "^2.2.1",
     "husky": "^6.0.0",
-    "lint-staged": "^10.5.4"
+    "lint-staged": "^10.5.4",
+    "prettier": "^2.2.1"
   },
   "husky": {
     "hooks": {

--- a/src/App.css
+++ b/src/App.css
@@ -6,3 +6,17 @@
   justify-content: center;
   color: black;
 }
+
+.App-container {
+  border: 1px solid white;
+  border-radius: 8px;
+  padding: 20px;
+  margin-bottom: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.App-container > * {
+  margin-bottom: 10px;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Patient, PatientsService } from "./patients/patients";
 import { createNewPatientsApi } from "./patients/patients_api";
 import { PatientsLoader } from "./patients/patients_loader_button";
 import { PatientsSearch } from "./patients/patients_search";
+import ToastProvider from "./toast/ToastProvider";
 
 function App() {
   const [patients, updatePatients] = useState<Patient[]>([]);
@@ -14,28 +15,33 @@ function App() {
 
   return (
     <div className="App">
-      <header className="App-header">
-        <h1>Welcome to Heartbeat 🏥</h1>
-        <div
-          style={{
-            border: "1px solid white",
-            borderRadius: "8px",
-            padding: "20px",
-            marginBottom: "20px",
-          }}
-        >
-          <h2>Please load the patients using the button below or search</h2>
-          <PatientsLoader
-            loadPatients={patientsApi.All}
-            onLoaded={updatePatients}
-          />
-          <PatientsSearch
-            loadPatients={patientsApi.Search}
-            onResults={updatePatients}
-          />
-          {patients.length > 0 && displayPatients(patients)}
-        </div>
-      </header>
+      <ToastProvider>
+        <header className="App-header">
+          <h1>Welcome to Heartbeat 🏥</h1>
+          <div
+            style={{
+              border: "1px solid white",
+              borderRadius: "8px",
+              padding: "20px",
+              marginBottom: "20px",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+            }}
+          >
+            <h2>Please load the patients using the button below or search</h2>
+            <PatientsLoader
+              loadPatients={patientsApi.All}
+              onLoaded={updatePatients}
+            />
+            <PatientsSearch
+              loadPatients={patientsApi.Search}
+              onResults={updatePatients}
+            />
+            {patients.length > 0 && displayPatients(patients)}
+          </div>
+        </header>
+      </ToastProvider>
     </div>
   );
 }
@@ -44,7 +50,7 @@ export default App;
 
 function displayPatients(patients: Patient[]) {
   return (
-    <ul>
+    <ul style={{ paddingLeft: "5px" }}>
       {patients.map((p, k) => (
         <li style={{ listStyle: "none" }} key={k}>
           ✅ {p.name}{" "}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,61 +1,29 @@
-import React, { useState } from "react";
+import React from "react";
 import "./App.css";
-import { Patient, PatientsService } from "./patients/patients";
-import { createNewPatientsApi } from "./patients/patients_api";
+import PatientsProvider from "./patients/PatientsProvider";
+import { PatientsList } from "./patients/patients_list";
 import { PatientsLoader } from "./patients/patients_loader_button";
 import { PatientsSearch } from "./patients/patients_search";
 import ToastProvider from "./toast/ToastProvider";
 
 function App() {
-  const [patients, updatePatients] = useState<Patient[]>([]);
-
-  const [patientsApi] = useState<PatientsService>(
-    createNewPatientsApi("http://localhost:3000")
-  );
-
   return (
     <div className="App">
-      <ToastProvider>
-        <header className="App-header">
-          <h1>Welcome to Heartbeat 🏥</h1>
-          <div
-            style={{
-              border: "1px solid white",
-              borderRadius: "8px",
-              padding: "20px",
-              marginBottom: "20px",
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-            }}
-          >
-            <h2>Please load the patients using the button below or search</h2>
-            <PatientsLoader
-              loadPatients={patientsApi.All}
-              onLoaded={updatePatients}
-            />
-            <PatientsSearch
-              loadPatients={patientsApi.Search}
-              onResults={updatePatients}
-            />
-            {patients.length > 0 && displayPatients(patients)}
-          </div>
-        </header>
-      </ToastProvider>
+      <PatientsProvider>
+        <ToastProvider>
+          <header className="App-header">
+            <h1>Welcome to Heartbeat 🏥</h1>
+            <div className="App-container">
+              <h2>Please load the patients using the button below or search</h2>
+              <PatientsLoader />
+              <PatientsSearch />
+              <PatientsList />
+            </div>
+          </header>
+        </ToastProvider>
+      </PatientsProvider>
     </div>
   );
 }
 
 export default App;
-
-function displayPatients(patients: Patient[]) {
-  return (
-    <ul style={{ paddingLeft: "5px" }}>
-      {patients.map((p, k) => (
-        <li style={{ listStyle: "none" }} key={k}>
-          ✅ {p.name}{" "}
-        </li>
-      ))}
-    </ul>
-  );
-}

--- a/src/patients/PatientsProvider.tsx
+++ b/src/patients/PatientsProvider.tsx
@@ -1,0 +1,35 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+import { Patient, PatientsService } from "./patients";
+import { createNewPatientsApi } from "./patients_api";
+
+const PatientsContext = createContext({
+  patients: [] as Patient[],
+  patientsApi: createNewPatientsApi("http://localhost:3000"),
+  updatePatients: (patients: Patient[]) => {},
+});
+
+const PatientsProvider = ({ children }: { children: JSX.Element }) => {
+  const [patients, updatePatients] = useState<Patient[]>([]);
+  const [patientsApi] = useState<PatientsService>(
+    createNewPatientsApi("http://localhost:3000")
+  );
+
+  useEffect(() => {
+    console.log("patients: ", patients);
+  }, [patients]);
+
+  return (
+    <PatientsContext.Provider value={{ patients, patientsApi, updatePatients }}>
+      {children}
+    </PatientsContext.Provider>
+  );
+};
+
+const usePatientsProvider = () => {
+  const { patients, patientsApi, updatePatients } = useContext(PatientsContext);
+  return { patients, patientsApi, updatePatients };
+};
+
+export { usePatientsProvider, PatientsContext };
+
+export default PatientsProvider;

--- a/src/patients/patients_list.tsx
+++ b/src/patients/patients_list.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { usePatientsProvider } from "./PatientsProvider";
+
+export const PatientsList = () => {
+  const { patients } = usePatientsProvider();
+
+  if (patients.length === 0) {
+    return <div>No patients</div>;
+  }
+
+  return (
+    <ul style={{ margin: "auto", padding: "inherit" }}>
+      {patients.map((p, k) => (
+        <li style={{ listStyle: "none" }} key={k}>
+          ✅ {p.name}{" "}
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/src/patients/patients_loader_button.tsx
+++ b/src/patients/patients_loader_button.tsx
@@ -1,22 +1,16 @@
 import { FunctionComponent } from "react";
 import { useToast } from "../toast/ToastProvider";
-import { Patient } from "./patients";
+import { usePatientsProvider } from "./PatientsProvider";
 
-type props = {
-  loadPatients: () => Promise<Patient[]>;
-  onLoaded: (ps: Patient[]) => void;
-};
-
-export const PatientsLoader: FunctionComponent<props> = ({
-  loadPatients,
-  onLoaded,
-}) => {
+export const PatientsLoader: FunctionComponent = () => {
   const { addToast } = useToast();
+  const { patientsApi, updatePatients } = usePatientsProvider();
 
   const makeRequest = () => {
-    loadPatients()
+    patientsApi
+      .All()
       .then((ps) => {
-        onLoaded(ps);
+        updatePatients(ps);
         addToast({
           title: "Successfully loaded all patients",
           status: "success",

--- a/src/patients/patients_loader_button.tsx
+++ b/src/patients/patients_loader_button.tsx
@@ -1,4 +1,5 @@
 import { FunctionComponent } from "react";
+import { useToast } from "../toast/ToastProvider";
 import { Patient } from "./patients";
 
 type props = {
@@ -10,10 +11,24 @@ export const PatientsLoader: FunctionComponent<props> = ({
   loadPatients,
   onLoaded,
 }) => {
+  const { addToast } = useToast();
+
   const makeRequest = () => {
     loadPatients()
-      .then((ps) => onLoaded(ps))
-      .catch((err) => alert(err));
+      .then((ps) => {
+        onLoaded(ps);
+        addToast({
+          title: "Successfully loaded all patients",
+          status: "success",
+        });
+      })
+      .catch((err) =>
+        addToast({
+          title: "Error loading all patients",
+          message: err,
+          status: "error",
+        })
+      );
   };
   return (
     <div>

--- a/src/patients/patients_search.test.tsx
+++ b/src/patients/patients_search.test.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import {
+  act,
+  fireEvent,
+  getByLabelText,
+  render,
+  waitFor,
+} from "@testing-library/react";
+import { PatientsSearch } from "./patients_search";
+import userEvent from "@testing-library/user-event";
+
+it("should call loadPatients when user types input", async () => {
+  const mockLoadPatients = jest.fn().mockResolvedValue([]);
+  const mockOnResults = jest.fn().mockReturnValue(null);
+
+  const { getByLabelText } = render(
+    <PatientsSearch loadPatients={mockLoadPatients} onResults={mockOnResults} />
+  );
+
+  const input = getByLabelText("search-input") as HTMLInputElement;
+
+  act(() => {
+    userEvent.type(input, "testing");
+  });
+
+  expect(mockLoadPatients).toHaveBeenCalledTimes(1);
+  jest.clearAllMocks();
+});
+
+it("should equal input when user types text", async () => {
+  const mockLoadPatients = jest.fn().mockResolvedValue([]);
+  const mockOnResults = jest.fn().mockReturnValue(null);
+
+  const { getByLabelText } = render(
+    <PatientsSearch loadPatients={mockLoadPatients} onResults={mockOnResults} />
+  );
+
+  const input = getByLabelText("search-input") as HTMLInputElement;
+
+  act(() => {
+    userEvent.type(input, "testing");
+  });
+
+  expect(input.value).toBe("testing");
+  jest.clearAllMocks();
+});

--- a/src/patients/patients_search.tsx
+++ b/src/patients/patients_search.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent, useEffect, useState } from "react";
 import { Patient, PatientSearchQuery } from "./patients";
-import * as lodash from "lodash";
+import { debounce } from "lodash";
 import { useToast } from "../toast/ToastProvider";
 
 type props = {
@@ -45,7 +45,7 @@ export const PatientsSearch: FunctionComponent<props> = ({
     setQuery(e.target.value);
   };
 
-  const debouncedHandler = lodash.debounce(changeHandler, 300);
+  const debouncedHandler = debounce(changeHandler, 300);
 
   return (
     <div>

--- a/src/patients/patients_search.tsx
+++ b/src/patients/patients_search.tsx
@@ -2,19 +2,13 @@ import { FunctionComponent, useEffect, useState } from "react";
 import { Patient, PatientSearchQuery } from "./patients";
 import { debounce } from "lodash";
 import { useToast } from "../toast/ToastProvider";
+import { usePatientsProvider } from "./PatientsProvider";
 
-type props = {
-  loadPatients: (query: PatientSearchQuery) => Promise<Patient[]>;
-  onResults: (ps: Patient[]) => void;
-};
-
-export const PatientsSearch: FunctionComponent<props> = ({
-  loadPatients,
-  onResults,
-}) => {
+export const PatientsSearch: FunctionComponent = () => {
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(false);
   const { addToast } = useToast();
+  const { patientsApi, updatePatients } = usePatientsProvider();
 
   useEffect(() => {
     makeRequest();
@@ -26,9 +20,10 @@ export const PatientsSearch: FunctionComponent<props> = ({
       name: query,
     };
 
-    loadPatients(sq)
+    patientsApi
+      .Search(sq)
       .then((ps) => {
-        onResults(ps);
+        updatePatients(ps);
         setLoading(false);
       })
       .catch((err) => {

--- a/src/toast/ToastContainer.tsx
+++ b/src/toast/ToastContainer.tsx
@@ -1,0 +1,18 @@
+import { ToastBox, ToastProps } from "./toast";
+
+export default function ToastContainer({ toasts }: { toasts: ToastProps[] }) {
+  return (
+    <>
+      {toasts &&
+        toasts.map((toast) => (
+          <ToastBox
+            key={toast.id}
+            id={toast.id}
+            title={toast.title}
+            message={toast.message}
+            status={toast.status}
+          />
+        ))}
+    </>
+  );
+}

--- a/src/toast/ToastContainer.tsx
+++ b/src/toast/ToastContainer.tsx
@@ -1,6 +1,6 @@
 import { ToastBox, ToastProps } from "./toast";
 
-export default function ToastContainer({ toasts }: { toasts: ToastProps[] }) {
+export const ToastContainer = ({ toasts }: { toasts: ToastProps[] }) => {
   return (
     <>
       {toasts &&
@@ -15,4 +15,4 @@ export default function ToastContainer({ toasts }: { toasts: ToastProps[] }) {
         ))}
     </>
   );
-}
+};

--- a/src/toast/ToastProvider.tsx
+++ b/src/toast/ToastProvider.tsx
@@ -3,8 +3,8 @@ import { ToastProps } from "./toast";
 import ToastContainer from "./ToastContainer";
 
 const ToastContext = React.createContext({
-  addToast: ({ title, message, status }: any) => {},
-  removeToast: (id: any) => {},
+  addToast: ({ title, message, status }: Omit<ToastProps, "id">) => {},
+  removeToast: (id: number) => {},
 });
 
 let id = 1;

--- a/src/toast/ToastProvider.tsx
+++ b/src/toast/ToastProvider.tsx
@@ -1,0 +1,56 @@
+import React, { useState, useContext, useCallback } from "react";
+import { ToastProps } from "./toast";
+import ToastContainer from "./ToastContainer";
+
+const ToastContext = React.createContext({
+  addToast: ({ title, message, status }: any) => {},
+  removeToast: (id: any) => {},
+});
+
+let id = 1;
+
+const ToastProvider = ({ children }: { children: JSX.Element }) => {
+  const [toasts, setToasts] = useState<ToastProps[]>([]);
+
+  const addToast = useCallback(
+    ({ title, message, status }) => {
+      setToasts((toasts) => [
+        ...toasts,
+        {
+          id: id++,
+          title: title,
+          message: message,
+          status: status,
+        },
+      ]);
+    },
+    [setToasts]
+  );
+
+  const removeToast = useCallback(
+    (id) => {
+      setToasts((toasts) => toasts.filter((t) => t.id !== id));
+    },
+    [setToasts]
+  );
+
+  return (
+    <ToastContext.Provider
+      value={{
+        addToast,
+        removeToast,
+      }}
+    >
+      <ToastContainer toasts={toasts} />
+      {children}
+    </ToastContext.Provider>
+  );
+};
+
+const useToast = () => {
+  const toastHelpers = useContext(ToastContext);
+  return toastHelpers;
+};
+
+export { ToastContext, useToast };
+export default ToastProvider;

--- a/src/toast/ToastProvider.tsx
+++ b/src/toast/ToastProvider.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext, useCallback } from "react";
 import { ToastProps } from "./toast";
-import ToastContainer from "./ToastContainer";
+import { ToastContainer } from "./ToastContainer";
 
 const ToastContext = React.createContext({
   addToast: ({ title, message, status }: Omit<ToastProps, "id">) => {},

--- a/src/toast/toast.tsx
+++ b/src/toast/toast.tsx
@@ -1,16 +1,32 @@
-import { FunctionComponent } from "react";
+import { FunctionComponent, useEffect } from "react";
 import "./toast.css";
-type props = {
+import { useToast } from "./ToastProvider";
+
+export type ToastProps = {
+  id: number;
   title: string;
   message?: string;
   status: "success" | "error";
 };
 
-export const ToastBox: FunctionComponent<props> = ({
+export const ToastBox: FunctionComponent<ToastProps> = ({
+  id,
   title,
   message,
   status,
 }) => {
+  const { removeToast } = useToast();
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      removeToast(id);
+    }, 3000);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [id, removeToast]);
+
   return (
     <div className={["toast", status].join(" ")}>
       <h6>{title}</h6>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1751,6 +1751,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/lodash@^4.14.179":
+  version "4.14.179"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.179.tgz#490ec3288088c91295780237d2497a3aa9dfb5c5"
+  integrity sha512-uwc1x90yCKqGcIOAT6DwOSuxnrAbpkdPsUOZtwrXb4D/6wZs+6qG7QnIawDuZWg0sWpxl+ltIKCaLoMlna678w==
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -7022,7 +7027,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.5:
+"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
- address the janky patients_search component by adding debounce on user input and only searching through patients with the name attribute

- add some tests for the patients_search component to check if the call to get patients is called + that input is what user enters

- add a loading text (not a spinner although that could be added easily too) to provide user with visual feedback while waiting for network request to complete

- improve error handling via usage of context api. ToastProvider can be accessed via any component down the tree to add/remove toast globally using the existing toast component

- currently toast is set to disappear after 3 seconds without needing to call remove